### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,32 @@ Dubbo-client-py supports configuring multiple zookeeper service addresses.
 "host":"192.168.1.183:2181,192.168.1.184:2181,192.168.1.185:2181"  
 Then the load balancing algorithm is implemented by proxy, and the server is called.    
 Support Version and Group settings.
-### Example
-	    config = ApplicationConfig('test_rpclib')
-	    service_interface = 'com.ofpay.demo.api.UserProvider'
-	    #Contains a connection to zookeeper, which needs caching.
-	    registry = ZookeeperRegistry('192.168.59.103:2181', config)
-	    user_provider = DubboClient(service_interface, registry, version='1.0')
-	    for i in range(1000):
-        try:
-            print user_provider.getUser('A003')
-            print user_provider.queryUser(
-                {u'age': 18, u'time': 1428463514153, u'sex': u'MAN', u'id': u'A003', u'name': u'zhangsan'})
-            print user_provider.queryAll()
-            print user_provider.isLimit('MAN', 'Joe')
-            print user_provider('getUser', 'A005')
 
-        except DubboClientError, client_error:
-            print client_error
-        time.sleep(5)
-	
+### Example
+
+```python
+# coding=utf-8
+import time
+from dubbo_client import ZookeeperRegistry, DubboClient, DubboClientError, ApplicationConfig
+
+config = ApplicationConfig('test_rpclib')
+service_interface = 'com.ofpay.demo.api.UserProvider'
+# Contains a connection to zookeeper, which needs caching.
+registry = ZookeeperRegistry('192.168.59.103:2181', config)
+user_provider = DubboClient(service_interface, registry, version='1.0')
+for i in range(1000):
+    try:
+        print user_provider.getUser('A003')
+        print user_provider.queryUser(
+            {u'age': 18, u'time': 1428463514153, u'sex': u'MAN', u'id': u'A003', u'name': u'zhangsan'})
+        print user_provider.queryAll()
+        print user_provider.isLimit('MAN', 'Joe')
+        print user_provider('getUser', 'A005')
+    except DubboClientError, client_error:
+        print client_error
+    time.sleep(5)
+```
+
 ### TODO
 Optimize performance, minimize the impact of service upper and lower lines.  
 Support Retry parameters  

--- a/dubbo_client/registry.py
+++ b/dubbo_client/registry.py
@@ -372,8 +372,11 @@ class MulticastRegistry(Registry):
             Thread.__init__(self)
             self.multicast_group, self.multicast_port = address.split(':')
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-            # in osx we should use SO_REUSEPORT instead of SO_REUSEADDRESS
-            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            # in osx we should use SO_REUSEPORT instead of SO_REUSEADDR
+            if getattr(socket, 'SO_REUSEPORT', None):
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            else:
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self.sock.bind(('', int(self.multicast_port)))
             mreq = struct.pack("4sl", socket.inet_aton(self.multicast_group), socket.INADDR_ANY)
             self.sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bunch==1.0.1
-kazoo==2.0
+kazoo==2.6.1
 py==1.4.26
 pytest==2.7.0
 python-jsonrpc==0.7.3


### PR DESCRIPTION
## platform

- win10
- zookeeper-3.4.14 in docker

## three commits

- add python format to the code in readme
- update the version of zk client: when using the `ZookeeperRegistry`  in `DubboClient`, I meet the bug https://github.com/python-zk/kazoo/issues/517, and fix it by updating the zk client's version from 2.0 to 2.6.1
- use `SO_REUSEADDR` in windows: because there is no `SO_REUSEPORT` in win